### PR TITLE
Adding privilege for RTM Login

### DIFF
--- a/src/Auth/AccessToken.php
+++ b/src/Auth/AccessToken.php
@@ -20,6 +20,7 @@ class AccessToken
         "kInvitePublishVideoStream"  => 11,
         "kInvitePublishDataStream"   => 12,
         "kAdministrateChannel"       => 101,
+        "kRtmLogin"                  => 1000,
     );
 
     public $appID, $appCertificate, $channelName, $uid;


### PR DESCRIPTION
Adding privilege for RTM login. This is to allow the generation of tokens to be used when logging in to the RTM service.